### PR TITLE
Add tests for timeseries regression fixes

### DIFF
--- a/pyam/core.py
+++ b/pyam/core.py
@@ -714,12 +714,9 @@ class IamDataFrame(object):
                     "Cannot use IAMC-index with continuous-time data format!"
                 )
             s = s.droplevel(self.extra_cols)
+
         df = s.unstack(level=self.time_col).rename_axis(None, axis=1).sort_index(axis=1)
 
-        if df.index.has_duplicates:
-            raise ValueError(
-                "Data with IAMC-index has duplicated index, use `iamc_index=False`"
-            )
         return df
 
     def reset_exclude(self):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -145,6 +145,16 @@ def test_df_year():
     yield df
 
 
+# minimal IamDataFrame for specifically testing 'time'-column features
+@pytest.fixture(scope="function")
+def test_df_time():
+    tdf = TEST_DF.rename({2005: TEST_DTS[0], 2010: TEST_DTS[1]}, axis="columns")
+    df = IamDataFrame(data=tdf)
+    for i in META_COLS:
+        df.set_meta(META_DF[i])
+    yield df
+
+
 # minimal test data as pandas.DataFrame (only 'year' time format)
 @pytest.fixture(scope="function")
 def test_pd_df():

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -643,9 +643,18 @@ def test_timeseries(test_df):
     npt.assert_array_equal(obs, exp)
 
 
-def test_timeseries_raises(test_df_year):
+def test_timeseries_empty_raises(test_df_year):
+    """Calling `timeseries()` on an empty IamDataFrame raises"""
     _df = test_df_year.filter(model="foo")
-    pytest.raises(ValueError, _df.timeseries)
+    with pytest.raises(ValueError,match="This IamDataFrame is empty!"):
+        _df.timeseries()
+
+
+def test_timeseries_time_iamc_raises(test_df_time):
+    """Calling `timeseries(iamc_index=True)` on a continuous-time IamDataFrame raises"""
+    match = "Cannot use IAMC-index with continuous-time data format!"
+    with pytest.raises(ValueError, match=match):
+        test_df_time.timeseries(iamc_index=True)
 
 
 def test_pivot_table(test_df):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -670,6 +670,20 @@ def test_timeseries_to_iamc_index(test_pd_df, test_df_year):
     pdt.assert_frame_equal(obs, exp)
 
 
+def test_timeseries_to_iamc_index_duplicated_raises(test_pd_df):
+    """Assert that using `timeseries(iamc_index=True)` raises if there are duplicates"""
+    test_pd_df = pd.concat([test_pd_df, test_pd_df])
+    # adding an extra-col creates a unique index
+    test_pd_df["foo"] = ["bar", "bar", "bar", "baz", "baz", "baz"]
+    exta_col_df = IamDataFrame(test_pd_df)
+    assert exta_col_df.extra_cols == ["foo"]
+
+    # dropping the extra-column by setting `iamc_index=True` creates duplicated index
+    match = "Index contains duplicate entries, cannot reshape"
+    with pytest.raises(ValueError, match=match):
+        exta_col_df.timeseries(iamc_index=True)
+
+
 def test_pivot_table(test_df):
     dct = {
         "model": ["model_a"] * 2,

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -6,6 +6,7 @@ import datetime
 import numpy as np
 import pandas as pd
 from numpy import testing as npt
+from pandas import testing as pdt
 
 from pyam import IamDataFrame, filter_by_meta, META_IDX, IAMC_IDX, sort_data, compare
 from pyam.core import _meta_idx, concat
@@ -655,6 +656,18 @@ def test_timeseries_time_iamc_raises(test_df_time):
     match = "Cannot use IAMC-index with continuous-time data format!"
     with pytest.raises(ValueError, match=match):
         test_df_time.timeseries(iamc_index=True)
+
+
+def test_timeseries_to_iamc_index(test_pd_df, test_df_year):
+    """Reducing timeseries() of an IamDataFrame with extra-columns to IAMC-index"""
+    test_pd_df["foo"] = "bar"
+    exta_col_df = IamDataFrame(test_pd_df)
+    assert exta_col_df.extra_cols == ["foo"]
+
+    # assert that reducing to IAMC-columns (dropping extra-columns) with timeseries()
+    obs = exta_col_df.timeseries(iamc_index=True)
+    exp = test_df_year.timeseries()
+    pdt.assert_frame_equal(obs, exp)
 
 
 def test_pivot_table(test_df):


### PR DESCRIPTION
Reviewing https://github.com/IAMconsortium/pyam/pull/503, the annoying "this line hasn't been touched by codecov" messages made me feel a bit sad, so I added some tests.

Made me realize that `unstack` fails if it results in a non-unique index, so I removed that check because you'll never get there. The error message is a bit less intuitive than I'd like ("Index contains duplicate entries, cannot reshape" instead of "Data with IAMC-index has duplicated index, use `iamc_index=False`"), but this is a non-essential feature, so our users will manage, I guess...